### PR TITLE
Added an optional parameter to next_wizard_path

### DIFF
--- a/lib/wicked/controller/concerns/path.rb
+++ b/lib/wicked/controller/concerns/path.rb
@@ -2,8 +2,8 @@ module Wicked::Controller::Concerns::Path
   extend ActiveSupport::Concern
 
 
-  def next_wizard_path
-    wizard_path(@next_step)
+  def next_wizard_path(options = {})
+    wizard_path(@next_step, options)
   end
 
   def controller


### PR DESCRIPTION
So we can pass additional options to the generated url. For example query parameters could be useful when not using a real model nor saving it in the update action. (this is my case)
