### PR TITLE
Use assign_attributes insted of update_attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ In addition to showing sequential views we can update elements in our controller
       @user = current_user
       case step
       when :confirm_password
-        @user.update_attributes(params[:user])
+        @user.assign_attributes(params[:user])
       end
       sign_in(@user, :bypass => true) # needed for devise
       render_wizard @user


### PR DESCRIPTION
If I use update_attributes, then the validations for the model are checked twice, one under the update_attributes call, and one inside the render_wizard method.

Using assign_attributes doesn't call any callback on the model, and so they are only called once when the model is saved inside the render_wizard method.
