### PR TITLE
I think it's better not to overwrite the 'controller' method

### DIFF
--- a/lib/wicked/controller/concerns/path.rb
+++ b/lib/wicked/controller/concerns/path.rb
@@ -10,18 +10,18 @@ module Wicked::Controller::Concerns::Path
     wizard_path(@previous_step, options)
   end
 
-  def my_controller
+  def wicked_controller
     params[:controller]
   end
 
-  def action
+  def wicked_action
     params[:action]
   end
 
 
   def wizard_path(goto_step = nil, options = {})
     options = {
-                 :controller => my_controller,
+                 :controller => wicked_controller,
                  :action     => 'show',
                  :id         => goto_step || params[:id],
                  :only_path  => true


### PR DESCRIPTION
If I use somewhere else the 'controller' method inside my controller (or in a helper method in my application_controller) it turns out that I can have troubles because it's now a String.

For example I'm using [gon](https://github.com/gazay/gon) and [Rabl](https://github.com/nesquena/rabl) to include some Javascript in my pages by default and so I have a before_filter in my ApplicationController.
Rabl calls controller_name on controller but that it is now a String and so it crashes.
