### PR TITLE
support string-based steps

### DIFF
--- a/lib/wicked/controller/concerns/render_redirect.rb
+++ b/lib/wicked/controller/concerns/render_redirect.rb
@@ -23,7 +23,7 @@ module Wicked::Controller::Concerns::RenderRedirect
   end
 
   def render_step(the_step, options = {})
-    if the_step.nil? || the_step == :finish
+    if the_step.nil? || the_step == 'finish'
       redirect_to_finish_wizard options
     else
       render the_step, options

--- a/lib/wicked/controller/concerns/steps.rb
+++ b/lib/wicked/controller/concerns/steps.rb
@@ -54,7 +54,7 @@ module Wicked::Controller::Concerns::Steps
   end
 
   def steps=(wizard_steps)
-    @wizard_steps = wizard_steps
+    @wizard_steps = wizard_steps.map(&:to_s)
   end
 
   def steps
@@ -65,7 +65,7 @@ module Wicked::Controller::Concerns::Steps
 
   def previous_step(current_step = nil)
     return @previous_step if current_step.nil?
-    index =  steps.index(current_step)
+    index =  steps.index(current_step.to_s)
     step  =  steps.at(index - 1) if index.present? && index != 0
     step ||= steps.first
     step
@@ -74,16 +74,16 @@ module Wicked::Controller::Concerns::Steps
 
   def next_step(current_step = nil)
     return @next_step if current_step.nil?
-    index = steps.index(current_step)
+    index = steps.index(current_step.to_s)
     step  = steps.at(index + 1) if index.present?
-    step  ||= :finish
+    step  ||= 'finish'
     step
   end
 
   private
 
   def step_index_for(step_name)
-    steps.index(step_name)
+    steps.index(step_name.to_s)
   end
 
   def current_step_index
@@ -91,7 +91,7 @@ module Wicked::Controller::Concerns::Steps
   end
 
   def current_and_given_step_exists?(step_name)
-    return false if current_step_index.nil? || steps.index(step_name).nil?
+    return false if current_step_index.nil? || steps.index(step_name.to_s).nil?
     return true
   end
 

--- a/lib/wicked/wizard.rb
+++ b/lib/wicked/wizard.rb
@@ -29,12 +29,12 @@ module Wicked
     end
 
     def check_redirect_to_first_last!(step)
-      redirect_to wizard_path(steps.first) if step == :wizard_first
-      redirect_to wizard_path(steps.last)  if step == :wizard_last
+      redirect_to wizard_path(steps.first) if step.to_s == 'wizard_first'
+      redirect_to wizard_path(steps.last)  if step.to_s == 'wizard_last'
     end
 
     def setup_step_from(the_step)
-      the_step = the_step.try(:to_sym) || steps.try(:first)
+      the_step = the_step.try(:to_s) || steps.try(:first)
       check_redirect_to_first_last!(the_step)
       return the_step
     end

--- a/lib/wicked/wizard/translated.rb
+++ b/lib/wicked/wizard/translated.rb
@@ -16,8 +16,8 @@ module Wicked
       def wizard_translations
         @wizard_translations ||= steps.inject(ActiveSupport::OrderedHash.new) do |hash, step|
           step        = step.to_s.split(".").last
-          translation = I18n.t("wicked.#{step}").to_sym
-          hash[translation] = step.to_sym
+          translation = I18n.t("wicked.#{step}")
+          hash[translation] = step.to_s
           hash
         end
       end

--- a/test/dummy/app/controllers/string_steps_controller.rb
+++ b/test/dummy/app/controllers/string_steps_controller.rb
@@ -1,0 +1,11 @@
+class StringStepsController < ApplicationController
+  include Wicked::Wizard
+  steps 'first', 'second', 'last_step'
+
+  def show
+    render_wizard
+  end
+
+  def update
+  end
+end

--- a/test/dummy/app/views/string_steps/_step_position.html.erb
+++ b/test/dummy/app/views/string_steps/_step_position.html.erb
@@ -1,0 +1,9 @@
+<% wizard_steps.each do |s| %>
+  <p>
+    <%= "#{s} step is the current step"    if current_step?(s)  %><br />
+    <%= "#{s} step is a past step"         if past_step?(s) %><br />
+    <%= "#{s} step is a future step"       if future_step?(s)   %><br />
+    <%= "#{s} step was the previous step"  if previous_step?(s)     %><br />
+    <%= "#{s} step is the next step"       if next_step?(s)     %><br />
+  </p>
+<% end %>

--- a/test/dummy/app/views/string_steps/second.html.erb
+++ b/test/dummy/app/views/string_steps/second.html.erb
@@ -1,0 +1,1 @@
+<%= render 'step_position' %>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -4,6 +4,7 @@ Dummy::Application.routes.draw do
   resources :jump
   resources :step_positions
   resources :dynamic_steps
+  resources :string_steps
 
   resources :nested do
     resources :builder, :controller => 'nested/builder'

--- a/test/integration/dynamic_steps_test.rb
+++ b/test/integration/dynamic_steps_test.rb
@@ -4,7 +4,7 @@ class DynamicStepsTest < ActiveSupport::IntegrationCase
   test 'set dynamic steps from params' do
     steps = [:first, :second]
     visit dynamic_steps_path(:steps => steps)
-    assert has_content?(steps.first.inspect)
-    assert has_content?(steps.inspect)
+    assert has_content?(steps.first)
+    assert has_content?(steps.map(&:to_s).inspect)
   end
 end

--- a/test/integration/steps_test.rb
+++ b/test/integration/steps_test.rb
@@ -23,6 +23,14 @@ class StepPositionsTest < ActiveSupport::IntegrationCase
     assert has_content?('last_step step is the next step')  # next_step?
   end
 
+  test 'string-based steps' do
+    visit(string_step_path('second'))
+    assert has_content?('second step is the current step')  # current_step?
+    assert has_content?('first step is a past step')        # past_step?
+    assert has_content?('last_step step is a future step')  # future_step?
+    assert has_content?('first step was the previous step') # previous_step?
+    assert has_content?('last_step step is the next step')  # next_step?
+  end
 end
 
   # current_step?


### PR DESCRIPTION
This change allows steps to be defined as strings in addition to symbols.  My use case was that I was generating the steps dynamically and by default they came out of my model as an array of strings. It took some time to realize that Wicked preferred symbols.

Cheers,
Steve
