### PR TITLE
Don't give the same steps array to all controllers.

### DIFF
--- a/lib/wicked/controller/concerns/steps.rb
+++ b/lib/wicked/controller/concerns/steps.rb
@@ -51,7 +51,7 @@ module Wicked::Controller::Concerns::Steps
       steps   = args
       check_protected!(steps)
       prepend_before_filter(options) do
-        self.steps = steps
+        self.steps = steps.dup
       end
     end
 


### PR DESCRIPTION
The expression passed to the filter in prepend_before_filter will reference the class copy of steps. This means that all controller instances have the same copy of the steps array, and should one instance of the controller edit the array, all instances will be affected, which could lead to concurrency problems.
