### PR TITLE
Added previous_step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Controller Tidbits:
 steps  :first, :second       # Sets the order of steps
 step                         # Gets symbol of current step
 next_step                    # Gets symbol of next step
+previous_step                # Gets symbol of previous step
 skip_step                    # Tells render_wizard to skip to the next logical step
 jump_to(:specific_step)      # Jump to :specific_step
 render_wizard                # Renders the current step


### PR DESCRIPTION
I'm not sure if previous_step is part of your public api so figured this was the best way to find out and let others know.

I need this for my current app so that if a user makes changes while navigating backwards through the wizard the changes will be saved. Given two submit buttons "Previous" and "Next" it looks like this:

```
    @user.assign_attributes(user_params)
    if params[:commit] == "Next"
      @user.step = step
    else
      jump_to previous_step
    end
    render_wizard @sponsorship_application
```
