### PR TITLE
Add primary_resource option

### DIFF
--- a/lib/wicked.rb
+++ b/lib/wicked.rb
@@ -21,6 +21,7 @@ class WickedProtectedStepError < WickedError; end
 require 'wicked/controller/concerns/render_redirect'
 require 'wicked/controller/concerns/steps'
 require 'wicked/controller/concerns/path'
+require 'wicked/controller/concerns/primary_resource'
 require 'wicked/wizard'
 require 'wicked/wizard/translated'
 require 'wicked/engine'

--- a/lib/wicked/controller/concerns/primary_resource.rb
+++ b/lib/wicked/controller/concerns/primary_resource.rb
@@ -1,0 +1,73 @@
+module Wicked::Controller::Concerns::PrimaryResource
+  extend ActiveSupport::Concern
+
+  included do
+    private
+
+    cattr_accessor :primary_resource_name
+  end
+
+  module ClassMethods
+    # For use with Wicked controllers nested beneath resource routes.
+    # If set, Wicked will automatically populate [resource_name]_id param value after creating a new resource.
+    # NOTE: Requires ivar with the same name to be set (see set_post method in example below).
+    #
+    # Example usage:
+    #
+    # config/routes.rb:
+    #
+    # resources :posts
+    #   resources :wizard, controller: 'post_wizard'
+    # end
+    #
+    # controller:
+    #
+    # class PostWizardController < Wicked::WizardController
+    #   primary_resource :post    # now, render_wizard(resource=nil, options={}) will attempt a save of the passed-in
+    #                             # resource, and, unless there are validation errors, will set the [resource_name]_id
+    #                             # param value to be @post.id (if not nil)
+    #   steps :create_post, :do_more_stuff, :last_step
+    #   before_action :set_post
+    #
+    #   def update
+    #     case step
+    #     when :create_post
+    #       @post.attributes = params[:post]
+    #
+    #     when :do_more_stuff
+    #       auxiliary_model = AuxiliaryModel.new(params[:auxiliary_model].merge(post: @post))
+    #       render_wizard(auxiliary_model) and return
+    #
+    #     when :last_step
+    #       @post.attributes = params[:post]
+    #     end
+    #
+    #     render_wizard(@post)
+    #   end
+    #
+    #   private
+    #
+    #   def set_post
+    #     if step == :create_post # AND/OR check for particular params[:post_id] value such as 'new'
+    #       @post = Post.new
+    #     else
+    #       @post = Post.find(params[:post_id])
+    #     end
+    #   end
+    # end
+    def primary_resource(resource_name)
+      self.primary_resource_name = resource_name
+    end
+  end
+
+  private
+
+  def primary_resource_name
+    self.class.primary_resource_name
+  end
+
+  def primary_resource
+    return nil unless primary_resource_name
+    instance_variable_get("@#{primary_resource_name}")
+  end
+end

--- a/lib/wicked/controller/concerns/render_redirect.rb
+++ b/lib/wicked/controller/concerns/render_redirect.rb
@@ -6,7 +6,11 @@ module Wicked::Controller::Concerns::RenderRedirect
     process_resource!(resource)
 
     if @skip_to
-      redirect_to wizard_path(@skip_to), options
+      path_options = {}
+      if primary_resource && (primary_resource_id = primary_resource.send(primary_resource.class.primary_key))
+        path_options[:"#{primary_resource_name}_id"] = primary_resource_id
+      end
+      redirect_to wizard_path(@skip_to, path_options), options
     else
       render_step wizard_value(step), options
     end

--- a/lib/wicked/wizard.rb
+++ b/lib/wicked/wizard.rb
@@ -18,6 +18,7 @@ module Wicked
     include Wicked::Controller::Concerns::Path
     include Wicked::Controller::Concerns::RenderRedirect
     include Wicked::Controller::Concerns::Steps
+    include Wicked::Controller::Concerns::PrimaryResource
 
     included do
       # Give our Views helper methods!

--- a/test/dummy/app/controllers/nested/builder_controller.rb
+++ b/test/dummy/app/controllers/nested/builder_controller.rb
@@ -3,6 +3,7 @@
 class Nested::BuilderController < ApplicationController
   include Wicked::Wizard
 
+  primary_resource :nested
   steps :first, :second, :last_step
 
   # nested_builder GET    /nested/:nested_id/builder/:id(.:format)      {:action=>"show", :controller=>"builder"}
@@ -14,5 +15,9 @@ class Nested::BuilderController < ApplicationController
   end
 
   def update
+    if step == :first
+      @nested = Nested.new
+      render_wizard(@nested)
+    end
   end
 end

--- a/test/dummy/app/models/nested.rb
+++ b/test/dummy/app/models/nested.rb
@@ -1,0 +1,12 @@
+class Nested
+  attr_reader :id
+
+  def self.primary_key
+    :id
+  end
+
+  def save
+    @id = 'persisted'
+    true
+  end
+end

--- a/test/dummy/app/views/nested/builder/first.html.erb
+++ b/test/dummy/app/views/nested/builder/first.html.erb
@@ -1,2 +1,5 @@
 first
 
+<%= form_for :nested, :url => wizard_path, :html => { :method => :put } do |f| %>
+  <%= f.submit 'Create Nested' %>
+<% end %>

--- a/test/integration/nested_builder_test.rb
+++ b/test/integration/nested_builder_test.rb
@@ -14,4 +14,11 @@ class NestedBuilderTest < ActiveSupport::IntegrationCase
     click_link 'next'
     assert_has_content?("home")
   end
+
+  test 'updates nested id param value after creating new records' do
+    visit nested_builder_path(:id => :first, :nested_id => "new")
+    click_button 'Create Nested'
+    assert_has_content?("second")
+    assert_equal(nested_builder_path(:id => :second, :nested_id => "persisted"), current_path)
+  end
 end


### PR DESCRIPTION
I am using a Wicked Wizard nested under a resource type, like so:

``` ruby
resources :posts
  resources :wizard, controller: 'post_wizard'
```

I want step 1 to do the actual post record creation, and every subsequent step to create auxiliary records or update the post in another manner. I therefore would prefer wicked to set :post_id automagically for me after creating the record in step 1.

This is different from the technique suggested here: https://github.com/schneems/wicked/wiki/Building-Partial-Objects-Step-by-Step which requires you to persist a “blank” record before entering step 1 of the wizard.

With this “primary_resource” technique, you can simply do:

``` ruby
class PostWizardController < Wicked::WizardController
  primary_resource :post
  …
end
```

and then as long as the `@post` ivar exists, once it is persisted (its id is set), the render_wizard method will change the params[:post_id] value according. The resulting URLs would look something like:
- Step 1: /posts/new/wizard/step1
  - “new” is a placeholder post_id
  - If form submission is successful, will update post_id in the url
  - Let’s say the id is 12345...
- Step 2: /posts/12345/wizard/step2
- Step X: /posts/12345/wizard/StepX

Thoughts on this technique?

I tried to add an appropriate test and good comments, let me know if I missed anything or if this change is a Bad Idea. :)
