### PR TITLE
Ignoring Ruby Gemset file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ test/dummy/tmp/
 
 Gemfile.lock
 .ruby-version
+.ruby-gemset


### PR DESCRIPTION
Usually if we're using rvm, would be a good be good if we use gemset to separate the gems. Especially when we're testing in difference rails versions.
