### PR TITLE
Add `steps` and `current_step_index` in view helper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ wizard_path                  # Grabs the current path in the wizard
 wizard_path(:specific_step)  # Url of the :specific_step
 next_wizard_path             # Url of the next step
 previous_wizard_path         # Url of the previous step
+steps                        # Gets array of steps
+step                         # Gets current step
+current_step_index           # Gets index of current step
 
 # These only work while in a Wizard, and are not absolute paths
 # You can have multiple wizards in a project with multiple `wizard_path` calls
@@ -437,4 +440,3 @@ gemfile if you are using a current version of Ruby.
 ## Contributing
 
 See the [Contributing guide](https://github.com/schneems/wicked/blob/master/CONTRIBUTING.md).
-

--- a/lib/wicked/controller/concerns/steps.rb
+++ b/lib/wicked/controller/concerns/steps.rb
@@ -93,14 +93,14 @@ module Wicked::Controller::Concerns::Steps
     step
   end
 
+  def current_step_index
+    step_index_for(step)
+  end
+
   private
 
   def step_index_for(step_name)
     steps.index(step_name)
-  end
-
-  def current_step_index
-    step_index_for(step)
   end
 
   def current_and_given_step_exists?(step_name)
@@ -108,4 +108,3 @@ module Wicked::Controller::Concerns::Steps
     return true
   end
 end
-

--- a/lib/wicked/wizard.rb
+++ b/lib/wicked/wizard.rb
@@ -24,7 +24,7 @@ module Wicked
       helper_method :wizard_path,     :next_wizard_path, :previous_wizard_path,
                     :step,            :wizard_steps,     :current_step?,
                     :past_step?,      :future_step?,     :previous_step?,
-                    :next_step?
+                    :next_step?,      :steps,            :current_step_index
       # Set @step and @next_step variables
       before_filter :setup_wizard
     end
@@ -79,4 +79,3 @@ module Wicked
     public
   end
 end
-


### PR DESCRIPTION
Sometime, we need to know `current_step_index` and list of `steps` in view.

For exemple to easily create a breadcrumb :

``` ruby
  <ol class="breadcrumb text-center">
    <% steps.each_with_index do |step, index| %>

      <% if index < (current_step_index - 1) %>
        <li><%= link_to I18n.t("wicked.#{step}"), wizard_path(step) %></li>
      <% elsif index == (current_step_index - 1) %>
        <li class="active"><%= link_to I18n.t("wicked.#{step}"), wizard_path(step) %></li>
      <% else %>
        <li><%= I18n.t("wicked.#{step}") %></li>
      <% end %>

    <% end %>
  </ol>
```
