### PR TITLE
Added after_finish callback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,14 @@ app/
 ```
 
 
+## Finish Logic
+You can specify a controller function to be called as the wizard completes the final step, before redirecting to the finish_wizard_path.
+```ruby
+def after_finish
+  ... some ruby code
+end
+```
+
 ## Finish Wizard Path
 
 You can specify the url that your user goes to by over-riding the `finish_wizard_path` in your wizard controller.

--- a/lib/wicked/controller/concerns/render_redirect.rb
+++ b/lib/wicked/controller/concerns/render_redirect.rb
@@ -43,8 +43,13 @@ module Wicked::Controller::Concerns::RenderRedirect
     '/'
   end
 
+  # the after_finish logic, can be overriden in controller
+  def after_finish
+  end
+
   def redirect_to_finish_wizard(options = {})
     Rails.logger.debug("Wizard has finished, redirecting to finish_wizard_path: #{finish_wizard_path.inspect}")
+    after_finish
     redirect_to finish_wizard_path, options
   end
 end


### PR DESCRIPTION
I had defined some finishing logic in my finish_wizard_path function, but noticed that the function gets called more than once.  So I added an after_finish callback to allow users to perform some cleanup logic before the final finishing redirect.  The after_finish function should be called only ONCE.