### PR TITLE
[Close #159] Fix double params

### DIFF
--- a/lib/wicked/wizard.rb
+++ b/lib/wicked/wizard.rb
@@ -31,8 +31,7 @@ module Wicked
 
     # forward to first step with whatever params are provided
     def index
-      query_string = "?#{request.query_parameters.to_query}" if request.query_parameters.any?
-      redirect_to "#{ wizard_path(steps.first) }#{ query_string || '' }"
+      redirect_to wizard_path(steps.first, request.query_parameters)
     end
 
     # returns the canonical value for a step name, needed for translation support


### PR DESCRIPTION
The `index` action assumed that there are no params when generating a URL, however this is not always true.

Someone can dynamically inject params by overwriting `default_url_options` like so:

```ruby
  def default_url_options(options = {})
    { locale: I18n.locale }.merge options
  end
```

When they do this, the redirect code in `index` would cause double params to show up.

The fix is to pass in params directly instead of manually trying to build up a URL for redirect. The solution is cleaner as well.