### PR TITLE
Change the runtime dependency to `railties`, not `rails`.

### DIFF
--- a/wicked.gemspec
+++ b/wicked.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
-  gem.add_dependency             "rails",    [">= 3.0.7"]
+  gem.add_dependency             "railties", [">= 3.0.7"]
+  gem.add_development_dependency "rails",    [">= 3.0.7"]
   gem.add_development_dependency "capybara", [">= 0"]
 end


### PR DESCRIPTION
`rails` will bring in other gems that wicked doesn't depend on and might not be
in use in the host app, like `activerecord`, `activejob` or `actionmailer`.

There might be a more elegant way to change this, but I couldn't figure out
exactly based on the existing Gemfiles and `Appraisal` file.