### PR TITLE
Fix documentation issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ class AfterSignupController < ApplicationController
     @user = current_user
     case step
     when :confirm_password
-      @user.update_attributes(params[:user])
+      @user.assign_attributes(params[:user])
     end
     sign_in(@user, bypass: true) # needed for devise
     render_wizard @user


### PR DESCRIPTION
When render_wizard is passed an object, it will attempt to save it.

Therefore, if one calls update_attributes on the object before render_wizard, two saves will be performed, as update_attributes also saves the object.

One should call assign_attributes to the object before passing it to render_wizard instead, as assign_attributes does not save the object.

I was led astray by the documentation and discovered the double save issue when my callback were being fired twice with deleterious effects!