### PR TITLE
Update documentation to explain double saves

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ end
 
 We're passing `render_wizard` our `@user` object here. If you pass an object into `render_wizard` it will show the next step if the object saves or re-render the previous view if it does not save.
 
+Note that `render_wizard` does attempt to save the passed object. This means that in the above example, the object will be saved twice. This will cause any callbacks to run twice also. If this is undesirable for your use case, then calling `assign_attributes` (which does not save the object) instead of `update_attributes` might work better.
 
 To get to this update action, you simply need to submit a form that PUT's to the same url
 


### PR DESCRIPTION
Update documentation to reflect that the AfterSignupController will cause @user to be saved twice.