### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ config.i18n.default_locale = :de
 ```
 
 **Important:** Don't forget to use `wizard_value()` method to make
-sure you are using the right cannonical values of `step`,
+sure you are using the right canonical values of `step`,
 `previous_step`, `next_step`, etc. If you are comparing them to non
 wicked generate values.
 


### PR DESCRIPTION
@schneems, I've corrected a typographical error in the documentation of the [wicked](https://github.com/schneems/wicked) project. Specifically, I've changed cannonical to canonical. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.