### PR TITLE
Preserve the options hash when not a params object

### DIFF
--- a/lib/wicked/controller/concerns/path.rb
+++ b/lib/wicked/controller/concerns/path.rb
@@ -20,7 +20,7 @@ module Wicked::Controller::Concerns::Path
 
 
   def wizard_path(goto_step = nil, options = {})
-    options = options.to_h if options.respond_to?(:permitted?) && options.respond_to?(:to_h)
+    options = options.respond_to?(:to_h) ? options.to_h : options
     options = { :controller => wicked_controller,
                 :action     => 'show',
                 :id         => goto_step || params[:id],


### PR DESCRIPTION
Before this change, if the second argument was not a params object,
`options` would be set to false. As a Hash responds to `.to_h` just send
it before the merge no matter what.

Fixes #205