### PR TITLE
readme: bundle install before appraisal install for dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,13 @@ Note: Rails 3.0 support is only for Ruby 1.9.3 or JRuby, not Ruby 2.0.0 or newer
 
 ## Running Gem Tests
 
-First install all gemfiles:
+First, install the development gems:
+
+```
+$ bundle install
+```
+
+Now that `appraisal` is installed, use it to set up all the gemfiles for the test matrix:
 
 ```
 $ appraisal install


### PR DESCRIPTION
I noticed this when jumping in to add another feature.

Currently it jumps straight to `appraisal` commands, which assumes that gem is installed.
The trouble is, installing it isn't enough. This happens under rbenv ruby 2.3.1:

![screen shot 2016-05-25 at 13 14 51](https://cloud.githubusercontent.com/assets/26158/15538337/d383c7e2-227b-11e6-91a4-c1cb651ada88.png)


Specifically:

```
➜  wicked git:(master) gem install appraisal
Fetching: appraisal-2.1.0.gem (100%)
Successfully installed appraisal-2.1.0
1 gem installed
➜  wicked git:(master) appraisal install
WARN: Unresolved specs during Gem::Specification.reset:
      rake (>= 0)
WARN: Clearing out unresolved specs.
Please report a bug if this causes problems.
Could not find gem 'sqlite3' in any of the gem sources listed in your Gemfile or available on this machine.
Run `bundle install` to install missing gems.

```

`bundle install` might be installing too much, but it's simple and works, and I guess we'll need the gems to do local development anyway.