### PR TITLE
Change `params[:id]` check to `params.key?(:id)`

### DIFF
--- a/lib/wicked/wizard.rb
+++ b/lib/wicked/wizard.rb
@@ -72,7 +72,7 @@ module Wicked
 
     def setup_wizard
       check_steps!
-      return if params[:id].nil?
+      return unless params.key?(:id)
 
       @step = setup_step_from(params[:id])
       set_previous_next(@step)


### PR DESCRIPTION
A minor adjustment, seemed more semantically "tight".