### PR TITLE
Fix issue with not being able to set a validation context

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,19 +183,20 @@ previous_wizard_path         # Url of the previous step
 **Controller Tidbits:**
 
 ```ruby
-steps  :first, :second       # Sets the order of steps
-step                         # Gets current step
-next_step                    # Gets next step
-previous_step                # Gets previous step
-skip_step                    # Tells render_wizard to skip to the next logical step
-jump_to(:specific_step)      # Jump to :specific_step
-render_wizard                # Renders the current step
-render_wizard(@user)         # Shows next_step if @user.save, otherwise renders
-wizard_steps                 # Gets ordered list of steps
-past_step?(step)             # does step come before the current request's step in wizard_steps
-future_step?(step)           # does step come after the current request's step in wizard_steps
-previous_step?(step)         # is step immediately before the current request's step
-next_step?(step)             # is step immediately after the current request's step
+steps  :first, :second                        # Sets the order of steps
+step                                          # Gets current step
+next_step                                     # Gets next step
+previous_step                                 # Gets previous step
+skip_step                                     # Tells render_wizard to skip to the next logical step
+jump_to(:specific_step)                       # Jump to :specific_step
+render_wizard                                 # Renders the current step
+render_wizard(@user)                          # Shows next_step if @user.save, otherwise renders
+render_wizard(@user, context: :account_setup) # Shows next_step if @user.save(context: :account_setup), otherwise renders
+wizard_steps                                  # Gets ordered list of steps
+past_step?(step)                              # does step come before the current request's step in wizard_steps
+future_step?(step)                            # does step come after the current request's step in wizard_steps
+previous_step?(step)                          # is step immediately before the current request's step
+next_step?(step)                              # is step immediately after the current request's step
 ```
 
 **Redirect options**

--- a/lib/wicked/controller/concerns/render_redirect.rb
+++ b/lib/wicked/controller/concerns/render_redirect.rb
@@ -3,7 +3,7 @@ module Wicked::Controller::Concerns::RenderRedirect
 
 
   def render_wizard(resource = nil, options = {}, params = {})
-    process_resource!(resource)
+    process_resource!(resource, options)
 
     if @skip_to
       url_params = (@wicked_redirect_params || {}).merge(params)
@@ -13,13 +13,19 @@ module Wicked::Controller::Concerns::RenderRedirect
     end
   end
 
-  def process_resource!(resource)
-    if resource
-      if resource.save
-        @skip_to ||= @next_step
-      else
-        @skip_to = nil
-      end
+  def process_resource!(resource, options = {})
+    return unless resource
+
+    saved = if resource.method(:save).arity >= 1
+              resource.save(context: options[:context])
+            else
+              resource.save
+            end
+
+    if saved
+      @skip_to ||= @next_step
+    else
+      @skip_to = nil
     end
   end
 
@@ -54,4 +60,3 @@ module Wicked::Controller::Concerns::RenderRedirect
     redirect_to wicked_final_redirect_path, options
   end
 end
-


### PR DESCRIPTION
This is a change for [Rails 5 support](http://blog.bigbinary.com/2016/04/08/validate-multiple-contexts-in-rails-5.html). I am not familiar enough with this test framework to properly spec this. Tested working locally via implementing project.