### PR TITLE
Remove Arity check that does not work with ActiveRecord objects

### DIFF
--- a/lib/wicked/controller/concerns/render_redirect.rb
+++ b/lib/wicked/controller/concerns/render_redirect.rb
@@ -16,7 +16,7 @@ module Wicked::Controller::Concerns::RenderRedirect
   def process_resource!(resource, options = {})
     return unless resource
 
-    if options[:context] && resource.method(:save).arity >= 1
+    if options[:context]
       did_save = resource.save(context: options[:context])
     else
       did_save = resource.save


### PR DESCRIPTION
The save method a standard ActiveRecord object has an Arity of -1, not 1 as expected by this code.

```ruby
User.first.method(:save).arity
> -1
```

The effect is that when we pass in a validation context it is not used.

Removing the check means that it works by default for ActiveRecord objects which is the main use of Wicked, and the only known use of the context option.