### PR TITLE
Use 422 instead of deprecated symbol :unprocessable_entity

### DIFF
--- a/lib/wicked/controller/concerns/render_redirect.rb
+++ b/lib/wicked/controller/concerns/render_redirect.rb
@@ -26,7 +26,7 @@ module Wicked::Controller::Concerns::RenderRedirect
     else
       @skip_to = nil
       # Do not override user-provided status for render
-      options[:status] ||= :unprocessable_entity
+      options[:status] ||= 422
     end
   end
 


### PR DESCRIPTION
Closes #308

This works both with older & newer rack versions.